### PR TITLE
fix: update querySelector to use decodeURIComponent for link hash

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -152,7 +152,7 @@ export function initBaseComponents(Alpine) {
             .slice()
             .reverse()
             .find((link) => {
-              const el = document.querySelector(link.hash)
+              const el = document.querySelector(encodeURIComponent(link.hash))
               return el.getBoundingClientRect().top <= 100
             }) ?? links[0]
 

--- a/js/main.js
+++ b/js/main.js
@@ -152,7 +152,7 @@ export function initBaseComponents(Alpine) {
             .slice()
             .reverse()
             .find((link) => {
-              const el = document.querySelector(encodeURIComponent(link.hash))
+              const el = document.querySelector(decodeURIComponent(link.hash))
               return el.getBoundingClientRect().top <= 100
             }) ?? links[0]
 


### PR DESCRIPTION
## Problem

If the hash link contains a non-English character string, the following error occurs.

```
Uncaught SyntaxError: Failed to execute 'querySelector' on 'Document': '#%E3%82%B9%E3%83%9D%E3%83%B3%E3%82%B5%E3%83%BC' is not a valid selector.
```

## Reproduction

Repository: https://github.com/7nohe/adonisjs-v6-docs-ja
Website: https://adonisjs-docs-ja.vercel.app


## Solution

Decode the hash link before passing it to `querySelector`.
